### PR TITLE
Add untested partitioning re-implementation

### DIFF
--- a/gpt.cfdisk
+++ b/gpt.cfdisk
@@ -1,0 +1,10 @@
+label: gpt
+label-id: 80BAAAEB-D06B-374A-9D86-05FF83243143
+device: /dev/vda
+unit: sectors
+first-lba: 2048
+last-lba: 41943006
+sector-size: 512
+
+/dev/vda1 : start=        2048, size=     2097152, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/vda2 : start=     2099200, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709

--- a/gpt.cfdisk
+++ b/gpt.cfdisk
@@ -2,5 +2,5 @@ label: gpt
 unit: sectors
 sector-size: 512
 
-/dev/vda1 : start=        2048, size=     2097152, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-/dev/vda2 : start=     2099200, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
+start=        2048, size=     2097152, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+start=     2099200, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709

--- a/gpt.cfdisk
+++ b/gpt.cfdisk
@@ -1,9 +1,5 @@
 label: gpt
-label-id: 80BAAAEB-D06B-374A-9D86-05FF83243143
-device: /dev/vda
 unit: sectors
-first-lba: 2048
-last-lba: 41943006
 sector-size: 512
 
 /dev/vda1 : start=        2048, size=     2097152, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B

--- a/mbr.cfdisk
+++ b/mbr.cfdisk
@@ -1,0 +1,8 @@
+label: dos
+label-id: 0xaf303494
+device: /dev/vda
+unit: sectors
+sector-size: 512
+
+/dev/vda1 : start=        2048, size=     2097152, type=83, bootable
+/dev/vda2 : start=     2099200, type=83

--- a/mbr.cfdisk
+++ b/mbr.cfdisk
@@ -1,6 +1,4 @@
 label: dos
-label-id: 0xaf303494
-device: /dev/vda
 unit: sectors
 sector-size: 512
 

--- a/mbr.cfdisk
+++ b/mbr.cfdisk
@@ -2,5 +2,5 @@ label: dos
 unit: sectors
 sector-size: 512
 
-/dev/vda1 : start=        2048, size=     2097152, type=83, bootable
-/dev/vda2 : start=     2099200, type=83
+start=        2048, size=     2097152, type=83, bootable
+start=     2099200, type=83


### PR DESCRIPTION
I haven't tested it yet, but I think this is probably much closer to what you are trying achieve.

I have implemented in to be NVMe aware, so it can deal with these weird drive names. It should also be able to deal with both EFI and BIOS systems.


Add the `*.sdisk` files to `$osidir` (default /etc/os-installer), these files are read by sfdisk to partition the disk appropriately. My familiarity with the partitioning of BIOS systems is limited, so I hope this config file is ok with the proper partition types set, they are both set to linux type.

Installation to a partition is not implemented and will quit the script with an error if used, last time I checked os-installed had a bug and returned an empty variable.